### PR TITLE
change toggle default to this.props.isOpen

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ let Popover = createClass({
       standing: 'above',
       exited: !this.props.isOpen, // for animation-dependent rendering, should popover close/open?
       exiting: false, // for tracking in-progress animations
-      toggle: false // for business logic tracking, should popover close/open?
+      toggle: this.props.isOpen // for business logic tracking, should popover close/open?
     }
   },
   getDefaultProps() {


### PR DESCRIPTION
Maybe I'm missing something, but without that change popover sometimes wouldn't close.
Also, w/o this change I often see: 
`Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op.`