### PR TITLE
When the space is not enough to contain the pop up use the best fit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ import resizeEvent from './on-resize'
 import Layout from './layout'
 import ReactLayerMixin from './react-layer-mixin'
 import { isServer, window } from './platform'
-import { arrayify, assign, clientOnly } from './utils'
+import { arrayify, clientOnly } from './utils'
 import Tip from './tip'
 
 
@@ -443,7 +443,7 @@ const Popover = createClass({
 
     const popoverProps = {
       className: `Popover ${className}`,
-      style: assign({}, coreStyle, style),
+      style: Object.assign({}, coreStyle, style),
     }
 
     const tipProps = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -396,7 +396,7 @@ const Popover = createClass({
       !this.containerEl.contains(event.target) &&
       !this.targetEl.contains(event.target)
     )
-    if (isOuterAction) this.props.onOuterAction()
+    if (isOuterAction) this.props.onOuterAction(event)
   },
   untrackPopover () {
     clearInterval(this.checkLayoutInterval)

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -135,7 +135,7 @@ const getPreferenceType = (preference) => (
 /* Dimension Fit Checks */
 
 const fitWithinChecker = (dimension) => (domainSize, itemSize) => (
-  domainSize[dimension] > itemSize[dimension]
+  domainSize[dimension] >= itemSize[dimension]
 )
 
 const doesWidthFitWithin = fitWithinChecker(`w`)
@@ -160,10 +160,8 @@ const createPreferenceError = (givenValue) => (
 
 
 
-/* Algorithm for picking the best fitting zone for popover. The current technique will loop through all zones picking the last one that fits. If
-none fit the last one is selected.
-
-TODO In the case that none fit we should pick the least-not-fitting zone. */
+/* Algorithm for picking the best fitting zone for popover. The current technique will loop through all zones picking the last one that fits.
+In the case that none fit we should pick the least-not-fitting zone. */
 
 const pickZone = (opts, frameBounds, targetBounds, size) => {
   const t = targetBounds
@@ -174,11 +172,21 @@ const pickZone = (opts, frameBounds, targetBounds, size) => {
     { side: `end`, standing: `below`, flow: `column`, order: 1, w: f.x2, h: (f.y2 - t.y2) },
     { side: `start`, standing: `left`, flow: `row`, order: -1, w: t.x, h: f.y2 },
   ]
-
+  
+  /* Order the zones by the amount of popup that would be cut out if that zone is used.
+     The first one in the array is the one that cuts the least amount.
+      
+     const area = size.w * size.h  // Popup area is constant and it does not change the order
+  */
+  zones.forEach((z) => {   
+    z.cutOff = /* area */ - Math.max(0, Math.min(z.w,size.w)) * Math.max(0, Math.min(z.h,size.h))
+  })
+  zones.sort((a,b) => a.cutOff - b.cutOff)
+  
   const availZones = zones.filter((zone) => (
     doesFitWithin(zone, size)
   ))
-
+  
   /* If a place is required pick it from the available zones if possible. */
 
   if (opts.place) {
@@ -190,17 +198,27 @@ const pickZone = (opts, frameBounds, targetBounds, size) => {
 
   /* If the preferred side is part of the available zones, use that otherwise
   pick the largest available zone. If there are no available zones, pick the
-  largest zone. TODO: logic that executes picking based on largest option. */
+  largest zone. */
 
   if (opts.preferPlace) {
     const preferenceType = getPreferenceType(opts.preferPlace)
     if (!preferenceType) throw createPreferenceError(opts.preferPlace)
+    
+    // Try to fit first in zone where the pop up fit completely
     const preferredAvailZones = availZones.filter((zone) => (
       zone[preferenceType] === opts.preferPlace
     ))
     if (preferredAvailZones.length) return preferredAvailZones[0]
+    
+    // If there are not areas where the pop up fit completely, it uses the prefered ones
+    // in order from the one the fit better
+    const preferredZones = zones.filter((zone) => (
+      zone[preferenceType] === opts.preferPlace
+    ))
+    if (preferredZones.length) return preferredZones[0]    
   }
 
+  // Return a zone that fit completely or the one that fit the best 
   return availZones.length ? availZones[0] : zones[0]
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,5 @@
-import AssignPolyFill from 'object.assign/polyfill'
 import { isClient } from './platform'
 
-
-
-const assign = AssignPolyFill()
 
 const arrayify = (x) => (
   Array.isArray(x) ? x : [x]
@@ -29,7 +25,6 @@ const clientOnly = (f) => (
 
 
 export default {
-  assign,
   arrayify,
   find,
   equalRecords,
@@ -37,7 +32,6 @@ export default {
   clientOnly,
 }
 export {
-  assign,
   arrayify,
   find,
   equalRecords,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "css-vendor": "^0.3.1",
     "debug": "^2.1.3",
     "lodash.throttle": "^3.0.3",
-    "object.assign": "^4.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was having problems on mobile where the pop up was always going out of viewport. 

This PR improve the positioning in case there are no zones that fit the popup.
The orientation is chosen based on the zone that cut the smallest area of the pop up.

`preferPlace` is also kept in consideration. For example if `preferPlace=column`, the pop up will be positioned among `above` and `below` based on the zone that show the largest part of the popup.

There is also a commit that remove the dependency on the assign polyfill that is automatically managed by babel. 

Also `onOuterAction` receive the outer event ( the `mousedown` or `touchstart` that generated it).