### PR TITLE
Popover is continuing to stay on screen even when the target is below the screen edge.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -201,6 +201,12 @@ const Popover = createClass({
     } else if (tb[axis.cross.end] < hangingBufferLength) {
       log(`popoverCrossStart cannot hang any further without losing target.`)
       pos[axis.cross.start] = tb[axis.cross.end] - hangingBufferLength
+      
+    /* checking if the cross start of the target area is within the frame and it makes sense 
+    to try fitting popover into the frame. */
+    } else if (tb[axis.cross.start] > frameCrossInnerEnd ) {
+      log(`popoverCrossStart cannot hang any further without losing target.`);
+      pos[axis.cross.start] = tb[axis.cross.start] - this.size[axis.cross.size];
 
     /* If the `popoverCrossStart` does not fit within the inner frame (honouring buffers) then
     just center the popover in the remaining `frameCrossLength`. */


### PR DESCRIPTION
Steps to reproduce:
1) open [playground](https://littlebits.github.io/react-popover/build/playground.html);
2) set "preferPlace" to "right" or "left";
3) move target element below the screen edge;
4) open popover;
5) scroll up;

**Expected behavior:** popover stays on the target;
**Actual behavior:** popover sticks to the bottom of the screen even when the target is far down.

Similarly you can observe this issue when you set "preferPlace" to "above" or "below" and place the target element far to the right.

The problem is that target's "upper" bound was not checked during popover layout. I'm not sure that my solution is the best-possible fix, but it seemed to fix this issue for me. 

Thanks for developing such a nice react component!
