### PR TITLE
Use available zones before defaulting to unavailable preferred zone

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -172,21 +172,21 @@ const pickZone = (opts, frameBounds, targetBounds, size) => {
     { side: `end`, standing: `below`, flow: `column`, order: 1, w: f.x2, h: (f.y2 - t.y2) },
     { side: `start`, standing: `left`, flow: `row`, order: -1, w: t.x, h: f.y2 },
   ]
-  
+
   /* Order the zones by the amount of popup that would be cut out if that zone is used.
      The first one in the array is the one that cuts the least amount.
-      
+
      const area = size.w * size.h  // Popup area is constant and it does not change the order
   */
-  zones.forEach((z) => {   
+  zones.forEach((z) => {
     z.cutOff = /* area */ - Math.max(0, Math.min(z.w,size.w)) * Math.max(0, Math.min(z.h,size.h))
   })
   zones.sort((a,b) => a.cutOff - b.cutOff)
-  
+
   const availZones = zones.filter((zone) => (
     doesFitWithin(zone, size)
   ))
-  
+
   /* If a place is required pick it from the available zones if possible. */
 
   if (opts.place) {
@@ -203,22 +203,22 @@ const pickZone = (opts, frameBounds, targetBounds, size) => {
   if (opts.preferPlace) {
     const preferenceType = getPreferenceType(opts.preferPlace)
     if (!preferenceType) throw createPreferenceError(opts.preferPlace)
-    
+
     // Try to fit first in zone where the pop up fit completely
     const preferredAvailZones = availZones.filter((zone) => (
       zone[preferenceType] === opts.preferPlace
     ))
     if (preferredAvailZones.length) return preferredAvailZones[0]
-    
-    // If there are not areas where the pop up fit completely, it uses the prefered ones
+
+    // If there are not areas where the pop up fit completely, it uses the preferred ones
     // in order from the one the fit better
     const preferredZones = zones.filter((zone) => (
       zone[preferenceType] === opts.preferPlace
     ))
-    if (preferredZones.length) return preferredZones[0]    
+    if (preferredZones.length) return preferredZones[0]
   }
 
-  // Return a zone that fit completely or the one that fit the best 
+  // Return a zone that fit completely or the one that fit the best
   return availZones.length ? availZones[0] : zones[0]
 }
 

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -215,7 +215,7 @@ const pickZone = (opts, frameBounds, targetBounds, size) => {
     const preferredZones = zones.filter((zone) => (
       zone[preferenceType] === opts.preferPlace
     ))
-    if (preferredZones.length) return preferredZones[0]
+    if (!availZones.length && preferredZones.length) return preferredZones[0]
   }
 
   // Return a zone that fit completely or the one that fit the best


### PR DESCRIPTION
r? @sch 
cc/ @jasonkuhrt, @ChrisCinelli 

Addresses issue mentioned [here](https://github.com/littlebits/react-popover/pull/60/files#r53562430) where preferred placement is selected over an available zone when no available preferred zones exist.

Before:
![falling-off-broken](https://cloud.githubusercontent.com/assets/2320890/13201380/7141dec2-d823-11e5-9b79-84d529308d06.gif)

After:
![falling-off-fixed](https://cloud.githubusercontent.com/assets/2320890/13201383/84e237a6-d823-11e5-8a74-1a06e807a64b.gif)

