### PR TITLE
Render context into the popver

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -418,7 +418,7 @@ const Popover = createClass({
     this.frameBounds = Layout.El.calcBounds(this.frameEl)
   },
   componentWillUnmount () {
-    clearInterval(this.checkLayoutInterval)
+    this.exit();
   },
   renderLayer () {
     if (this.state.exited) return null

--- a/lib/index.js
+++ b/lib/index.js
@@ -418,7 +418,7 @@ const Popover = createClass({
     this.frameBounds = Layout.El.calcBounds(this.frameEl)
   },
   componentWillUnmount () {
-    this.exit();
+    this.untrackPopover();
   },
   renderLayer () {
     if (this.state.exited) return null

--- a/lib/index.js
+++ b/lib/index.js
@@ -387,7 +387,9 @@ const Popover = createClass({
   },
   untrackPopover () {
     clearInterval(this.checkLayoutInterval)
-    this.frameEl.removeEventListener(`scroll`, this.onFrameScroll)
+    if (this.frameEl) {
+      this.frameEl.removeEventListener(`scroll`, this.onFrameScroll)
+    }
     resizeEvent.off(this.frameEl, this.onFrameResize)
     resizeEvent.off(this.containerEl, this.onPopoverResize)
     resizeEvent.off(this.targetEl, this.onTargetResize)

--- a/lib/on-resize.js
+++ b/lib/on-resize.js
@@ -13,6 +13,9 @@ let namespace = `__resizeDetector__`
 export { on as addEventListener, off as removeEventListener }
 
 export function on (el, fn) {
+  if (!el) {
+    return;
+  }
 
   /* Window object natively publishes resize events. We handle it as a
   special case here so that users do not have to think about two APIs. */
@@ -29,6 +32,10 @@ export function on (el, fn) {
 }
 
 export function off (el, fn) {
+  if (!el) {
+    return;
+  }
+	
   if (el === window) {
     window.removeEventListener(`resize`, fn)
     return

--- a/lib/on-resize.js
+++ b/lib/on-resize.js
@@ -110,6 +110,7 @@ const off = (el, fn) => {
     window.removeEventListener(`resize`, fn)
     return
   }
+  if (!el) return
   const detector = el[namespace]
   if (!detector) return
   const i = detector.listeners.indexOf(fn)

--- a/lib/react-layer-mixin.js
+++ b/lib/react-layer-mixin.js
@@ -1,5 +1,5 @@
-import { DOM as E, unmountComponentAtNode } from 'react'
-import { render } from 'react-dom'
+import { DOM as E } from 'react'
+import { render, unmountComponentAtNode } from 'react-dom'
 import { noop } from './utils'
 import { isClient } from './platform'
 

--- a/lib/react-layer-mixin.js
+++ b/lib/react-layer-mixin.js
@@ -20,7 +20,9 @@ const ReactLayerMixin = () => (
     componentWillUnmount () {
       this._layerUnrender()
       /* Unmount the mount. */
-      document.body.removeChild(this.layerContainerNode)
+      if (this.layerContainerNode.parentElement) {
+      	this.layerContainerNode.parentElement.removeChild(this.layerContainerNode);
+      }
     },
     _layerRender () {
       const layerReactEl = this.renderLayer()

--- a/lib/react-layer-mixin.js
+++ b/lib/react-layer-mixin.js
@@ -1,5 +1,8 @@
 import { DOM as E } from 'react'
-import { render, unmountComponentAtNode } from 'react-dom'
+import {
+  unstable_renderSubtreeIntoContainer as renderSubtreeIntoContainer, // eslint-disable-line camelcase
+  unmountComponentAtNode,
+} from 'react-dom'
 import { noop } from './utils'
 import { isClient } from './platform'
 
@@ -39,9 +42,9 @@ const ReactLayerMixin = () => ({
     const layerReactEl = this.renderLayer()
     if (!layerReactEl) {
       this.layerReactComponent = null
-      render(E.noscript(), this.layerContainerNode)
+      renderSubtreeIntoContainer(this, E.noscript(), this.layerContainerNode)
     } else {
-      this.layerReactComponent = render(layerReactEl, this.layerContainerNode)
+      this.layerReactComponent = renderSubtreeIntoContainer(this, layerReactEl, this.layerContainerNode)
     }
   },
   _layerUnrender () {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/littlebits/react-popover.git"
+    "url": "https://github.com/clayne11/react-popover.git"
   },
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
-  "name": "react-popover",
-  "homepage": "https://github.com/littlebits/react-popover",
-  "version": "0.3.5",
+  "name": "react-popover-fork",
+  "homepage": "https://github.com/clayne11/react-popover",
+  "version": "0.3.6",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover-fork",
   "homepage": "https://github.com/littlebits/react-popover",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,3 +51,4 @@
     "url": "https://github.com/littlebits/react-popover/issues"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover-fork",
   "homepage": "https://github.com/clayne11/react-popover",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover-fork",
   "homepage": "https://github.com/littlebits/react-popover",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover-fork",
   "homepage": "https://github.com/clayne11/react-popover",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/littlebits/react-popover.git"
   },
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
-  "name": "react-popover",
+  "name": "react-popover-fork",
   "homepage": "https://github.com/littlebits/react-popover",
   "version": "0.5.0",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover",
   "homepage": "https://github.com/littlebits/react-popover",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {
@@ -57,4 +57,3 @@
     ]
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover-fork",
   "homepage": "https://github.com/clayne11/react-popover",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover-fork",
   "homepage": "https://github.com/clayne11/react-popover",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover-fork",
   "homepage": "https://github.com/littlebits/react-popover",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover-fork",
   "homepage": "https://github.com/clayne11/react-popover",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
   "name": "react-popover-fork",
   "homepage": "https://github.com/littlebits/react-popover",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/clayne11/react-popover.git"
+    "url": "https://github.com/littlebits/react-popover.git"
   },
   "author": "Jason Kuhrt <jasonkuhrt@me.com> (http://jasonkuhrt.com/)",
-  "name": "react-popover-fork",
-  "homepage": "https://github.com/clayne11/react-popover",
-  "version": "0.3.11",
+  "name": "react-popover",
+  "homepage": "https://github.com/littlebits/react-popover",
+  "version": "0.3.5",
   "main": "build/index.js",
   "description": "A specification backed popover for react",
   "devDependencies": {


### PR DESCRIPTION
When rendering the popover, we need to keep the context.

Render using ReactDOM.renderSubtreeIntoContainer rather than ReactDOM.render.

Fixes #66 
