### PR TITLE
Add event listeners to document instead of window

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ import * as cssVendor from 'css-vendor'
 import resizeEvent from './on-resize'
 import Layout from './layout'
 import ReactLayerMixin from './react-layer-mixin'
-import { isServer, window } from './platform'
+import { isServer, window, document } from './platform'
 import { arrayify, clientOnly } from './utils'
 import Tip from './tip'
 
@@ -379,8 +379,8 @@ const Popover = createClass({
     /* Track user actions on the page. Anything that occurs _outside_ the Popover boundaries
     should close the Popover. */
 
-    window.addEventListener(`mousedown`, this.checkForOuterAction)
-    window.addEventListener(`touchstart`, this.checkForOuterAction)
+    document.addEventListener(`mousedown`, this.checkForOuterAction)
+    document.addEventListener(`touchstart`, this.checkForOuterAction)
 
     /* Kickstart layout at first boot. */
 
@@ -402,8 +402,8 @@ const Popover = createClass({
     resizeEvent.off(this.frameEl, this.onFrameResize)
     resizeEvent.off(this.containerEl, this.onPopoverResize)
     resizeEvent.off(this.targetEl, this.onTargetResize)
-    window.removeEventListener(`mousedown`, this.checkForOuterAction)
-    window.removeEventListener(`touchstart`, this.checkForOuterAction)
+    document.removeEventListener(`mousedown`, this.checkForOuterAction)
+    document.removeEventListener(`touchstart`, this.checkForOuterAction)
   },
   onTargetResize () {
     log(`Recalculating layout because _target_ resized!`)

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -2,6 +2,7 @@
 const isServer = typeof window === `undefined`
 const isClient = !isServer
 const WINDOW = isClient ? window : null
+const DOCUMENT = isClient ? document : null;
 
 
 
@@ -9,9 +10,11 @@ export default {
   isServer,
   isClient,
   window: WINDOW,
+  document: DOCUMENT
 }
 export {
   isServer,
   isClient,
   WINDOW as window,
+  DOCUMENT as document
 }


### PR DESCRIPTION
Certain libraries absorb DOM events before it propagates to window object. Instead bind them to document. This PR fixes the already closed issue https://github.com/littlebits/react-popover/issues/56
