### PR TITLE
Fix issue #53 - ignore removing detector if node was unmounted

### DIFF
--- a/lib/on-resize.js
+++ b/lib/on-resize.js
@@ -76,9 +76,12 @@ const initialize = (el) => {
     }
     detector.destroy = () => {
       if (detector.elWasStaticPosition) el.style.position = ``
-      // Event handlers will be automatically removed.
-      // http://stackoverflow.com/questions/12528049/if-a-dom-element-is-removed-are-its-listeners-also-removed-from-memory
-      el.removeChild(objEl)
+
+      if (el.contains(objEl)) {
+        // Event handlers will be automatically removed.
+        // http://stackoverflow.com/questions/12528049/if-a-dom-element-is-removed-are-its-listeners-also-removed-from-memory
+        el.removeChild(objEl);
+      }
     }
 
     el.appendChild(objEl)


### PR DESCRIPTION
This addresses issue #53. In cases where the underlying detector target element changes before the detector can be destroyed, `removeChild` will fail because the element that `el` references has changed, and `objEl` is no longer a child.

r? @sch
