### PR TITLE
feat(Popover): adds trigger for animations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,6 +46,11 @@ Determines Whether or not the popover is rendered.
 
 ---
 
+##### `disableAnimations :: Boolean`
+Disables all the animations.
+
+---
+
 ##### `preferPlace :: Enum String | Null`
 Sets a ***preference*** of where to position the Popover. Only useful to specify placement in case of multiple available fits. Defaults to `null`. Valid values are:
 
@@ -70,7 +75,7 @@ A callback function executed every time the user does an action (`mousedown` or 
 ##### `refreshIntervalMs :: Number | Falsey`
 The polling speed (AKA time between each poll) in milliseconds for checking if a layout refresh is required. This polling is required because it is the only robust way to track the position of a target in the DOM. Defaults to `200`. Set to a falsey value to disable.
 
---- 
+---
 
 ##### Standard
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,7 @@ const Popover = createClass({
     enterExitTransitionDurationMs: T.number,
     className: T.string,
     style: T.object,
+    disableAnimations: T.boolean
   },
   mixins: [ReactLayerMixin()],
   getDefaultProps () {
@@ -84,6 +85,7 @@ const Popover = createClass({
       enterExitTransitionDurationMs: 500,
       children: null,
       refreshIntervalMs: 200,
+      disableAnimations: false
     }
   },
   getInitialState () {
@@ -305,6 +307,11 @@ const Popover = createClass({
     this.setState({ exiting: false })
   },
   animateExit () {
+  	if (this.props.disableAnimations) {
+  		  this.containerEl.style.opacity = `0`
+  		  this.tipEl.style.opacity = `0`
+  		  return
+  	}
     this.setState({ exiting: true })
     this.exitingAnimationTimer2 = setTimeout(() => {
       setTimeout(() => {
@@ -318,6 +325,12 @@ const Popover = createClass({
     }, this.props.enterExitTransitionDurationMs)
   },
   animateEnter () {
+  	if (this.props.disableAnimations) {
+  		  this.containerEl.style.opacity = `1`
+  		  this.tipEl.style.opacity = `1`
+  		  return
+  		}
+
     /* Prepare `entering` style so that we can then animate it toward `entered`. */
 
     this.containerEl.style.transform = `${flowToPopoverTranslations[this.zone.flow]}(${this.zone.order * 50}px)`


### PR DESCRIPTION
Adds a property to disable animations. 
This is useful for rerendering the popover from the outside.