### PR TITLE
Make minScrollRefreshIntervalMs configurable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,7 @@ const Popover = createClass({
     style: T.object,
     tipSize: T.number,
     onOuterAction: T.func,
+    minScrollRefreshIntervalMs: T.number
   },
   mixins: [ReactLayerMixin()],
   getDefaultProps () {
@@ -84,6 +85,7 @@ const Popover = createClass({
       enterExitTransitionDurationMs: 500,
       children: null,
       refreshIntervalMs: 200,
+      minScrollRefreshIntervalMs: 200
     }
   },
   getInitialState () {
@@ -342,7 +344,7 @@ const Popover = createClass({
     this.containerEl.style[jsprefix("Transform")] = this.containerEl.style.transform
   },
   trackPopover () {
-    const minScrollRefreshIntervalMs = 200
+    const minScrollRefreshIntervalMs = this.props.minScrollRefreshIntervalMs
     const minResizeRefreshIntervalMs = 200
 
     /* Get references to DOM elements. */


### PR DESCRIPTION
I had a strange case, where popover stacked up during scrolling. The only thing, which helped, was increasing number for this variable. So I'd like to have it as a prop.