### PR TITLE
Navigator not defined bug -> Update debug version to ^2.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "create-react-class": "^15.5.3",
     "css-vendor": "^0.3.1",
-    "debug": "^2.1.3",
+    "debug": "^2.6.8",
     "lodash.throttle": "^3.0.3",
     "prop-types": "^15.5.10"
   },


### PR DESCRIPTION
Hi all,

I'm using react-popover with react components rendered on server side. Currently it's not possible, because 'debug' lib, that is dependency for 'react-popover' is trying to get property of navigator which is not defined outside the browser. I checked 'debug' library and they fixed it in version 2.6.8, so I recommend to bump debug version to ^2.6.8 as in commit.

Cheers
Kuba