### PR TITLE
#107 - fixed enter animation time

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -334,10 +334,13 @@ const Popover = createReactClass({
     /* Hack: http://stackoverflow.com/questions/3485365/how-can-i-force-webkit-to-redraw-repaint-to-propagate-style-changes */
     this.containerEl.offsetHeight
 
-    this.tipEl.style.transition = "transform 150ms ease-in"
-    this.tipEl.style[jsprefix("Transition")] = `${cssprefix("transform")} 150ms ease-in`
+    /* If enterExitTransitionDurationMs is falsy, tip animation should be also disabled */
+    if (this.props.enterExitTransitionDurationMs) {
+      this.tipEl.style.transition = "transform 150ms ease-in"
+      this.tipEl.style[jsprefix("Transition")] = `${cssprefix("transform")} 150ms ease-in`
+    }
     this.containerEl.style.transitionProperty = "top, left, opacity, transform"
-    this.containerEl.style.transitionDuration = "500ms"
+    this.containerEl.style.transitionDuration = `${this.props.enterExitTransitionDurationMs} ms`
     this.containerEl.style.transitionTimingFunction = "cubic-bezier(0.230, 1.000, 0.320, 1.000)"
     this.containerEl.style.opacity = "1"
     this.containerEl.style.transform = "translateY(0)"


### PR DESCRIPTION
Hi guys,

this PR is fixing #107 issue. enterExitTransitionDurationMs prop is now used also for initial container animation and tip animation is disabled if time is falsy.

Cheers 
Kuba