### PR TITLE
Fix `transitionDuration` property typo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -340,7 +340,7 @@ const Popover = createReactClass({
       this.tipEl.style[jsprefix("Transition")] = `${cssprefix("transform")} 150ms ease-in`
     }
     this.containerEl.style.transitionProperty = "top, left, opacity, transform"
-    this.containerEl.style.transitionDuration = `${this.props.enterExitTransitionDurationMs} ms`
+    this.containerEl.style.transitionDuration = `${this.props.enterExitTransitionDurationMs}ms`
     this.containerEl.style.transitionTimingFunction = "cubic-bezier(0.230, 1.000, 0.320, 1.000)"
     this.containerEl.style.opacity = "1"
     this.containerEl.style.transform = "translateY(0)"


### PR DESCRIPTION
Fixes #127.

There can't be a space between the number and 'ms', or it is not recognized as a valid CSS value.