### PR TITLE
Use react-dom-factories to fix deprecated warning

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
-import { createElement, DOM as E,  } from "react"
+import { createElement } from "react"
+import E from "react-dom-factories"
 import { PropTypes as T } from "prop-types"
 import createReactClass from "create-react-class"
 import { findDOMNode } from "react-dom"

--- a/lib/react-layer-mixin.js
+++ b/lib/react-layer-mixin.js
@@ -1,4 +1,4 @@
-import { DOM as E } from "react"
+import E from "react-dom-factories"
 import ReactDOM from "react-dom"
 import { noop } from "./utils"
 import { isClient } from "./platform"

--- a/lib/tip.js
+++ b/lib/tip.js
@@ -1,4 +1,4 @@
-import { DOM as E } from "react"
+import E from "react-dom-factories"
 import createReactClass from "create-react-class"
 
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "css-vendor": "^0.3.1",
     "debug": "^2.6.8",
     "lodash.throttle": "^3.0.3",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "react-dom-factories": "^1.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix #124 warning :
> Warning: Accessing factories like React.DOM.noscript has been deprecated and will be removed in v16.0+.

See https://www.npmjs.com/package/react-dom-factories for more info