### PR TITLE
fix: popover glitch, tip jumps #125

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -421,8 +421,14 @@ const Popover = createReactClass({
   },
   onPopoverResize () {
     log("Recalculating layout because _popover_ resized!")
+    const prevHeight = this.size.h
+    const prevWidth = this.size.w
     this.measurePopoverSize()
-    this.resolvePopoverLayout()
+    const newHeight = this.size.h
+    const newWidth = this.size.w
+    if((newHeight - prevHeight > this.tipSize) || (newWidth - prevWidth > this.tipSize)) {
+      this.resolvePopoverLayout()
+    }
   },
   onFrameScroll () {
     log("Recalculating layout because _frame_ scrolled!")


### PR DESCRIPTION
On popoverResize event is firing even if the size of the popover haven't really changed (due on the late attachement of the tip to the `containerEl`), the popoverResize re-`resolvePopoverLayout` causing the jumping glitch. You can see that the event is firing even in the first toggle, and the diff of the height is exactly the size of the tip.

![fix-glitch](https://user-images.githubusercontent.com/283690/30066024-01f1ea18-9257-11e7-934d-fb5c5f00a013.gif)

This tries to fix it by ensuring that the resize is at least > than the tipSize.
