### PR TITLE
fix: document is not defined on server

### DIFF
--- a/lib/react-layer-mixin.js
+++ b/lib/react-layer-mixin.js
@@ -19,11 +19,13 @@ const removeElement = (x, target) =>
 const ReactLayerMixin = () => ({
   componentWillMount () {
     this.targetBounds = null
-    this.appendTarget = document.body
+
     /* Create a DOM node for mounting the React Layer. */
     this.layerContainerNode = createElement("div")
   },
   componentDidMount () {
+    this.appendTarget = document.body
+
     if (this.props.appendTarget && document.querySelector(this.props.appendTarget)) {
       this.appendTarget = document.querySelector(this.props.appendTarget)
     }


### PR DESCRIPTION
Because document is getting called in the `ReactLayerMixin` `componentWillMount` lifecycle method it throws a `document is undefined` error on the server for universal web apps. 