### PR TITLE
Fix a few migration issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 // http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default
 
-const lib = require("./build/main")
+const lib = require("./build")
 module.exports = lib.default

--- a/lib/index.js
+++ b/lib/index.js
@@ -408,6 +408,7 @@ class Popover extends React.Component {
     resizeEvent.off(this.targetEl, this.onTargetResize)
     document.removeEventListener("mousedown", this.checkForOuterAction)
     document.removeEventListener("touchstart", this.checkForOuterAction)
+    this.hasTracked = false
   }
   onTargetResize = () => {
     log("Recalculating layout because _target_ resized!")

--- a/lib/index.js
+++ b/lib/index.js
@@ -461,7 +461,7 @@ class Popover extends React.Component {
     )
     return [
       <div key="1" ref={this.getTargetNodeRef}>{this.props.children}</div>,
-      ReactDOM.createPortal(popover, this.props.appendTarget)
+      !isServer && ReactDOM.createPortal(popover, this.props.appendTarget),
     ]
   }
 }


### PR DESCRIPTION
I broke these up into separate commits, so please feel free to cherry-pick if you aren't satisfied with all.

I just upgraded to React 16 and your latest release and unfortunately still had some issues.

First, 8917a44 fixes an error I was getting when importing. It was unable to resolve `build/main`, as it does not exist.

499eb4c addresses a bug I ran into that should be reproducible with the following steps:
1. Load a page with a popover
1. Open the popover
1. Close the popover (so `exit()` is called)
1. Navigate elsewhere or do something that will cause `componentWillUnmount` to get called

The issue was that `componentWillUnmount` and `exit` both call `untrackPopover`, but if `exit` has already been called, an error will be thrown when trying to unbind events.

434bd80 is addressing an SSR issue I have been having. `ReactDOM.createPortal` [requires the second argument to be a DOM element](https://github.com/facebook/react/blob/96fde8a09ad525f28910de2c95f0eee2d824d939/docs/docs/portals.md). When `isServer` evaluates to true, it is being set to `null` and thus throwing an error when the server attempts to render.  The code change will either return `false` or continue with the `createPortal` call, allowing the server to render.