### PR TITLE
[URGENT] Fix already published version (which is broken)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 // http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default
 
-const lib = require("./build/main")
+const lib = require("./build/index")
 module.exports = lib.default


### PR DESCRIPTION
⚠️ Currently published version doesn't work!

`main.js` doesn't exists in the `build` folder.