### PR TITLE
Remove useless div around this.props.children

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -460,7 +460,7 @@ class Popover extends React.Component {
       </div>
     )
     return [
-      <div key="1" ref={this.getTargetNodeRef}>{this.props.children}</div>,
+      React.cloneElement(this.props.children, { ref: this.getTargetNodeRef }),
       Platform.isClient && ReactDOM.createPortal(popover, this.props.appendTarget),
     ]
   }


### PR DESCRIPTION
Introduced in the React 16 support, an enclosing div was set around `this.props.children`.
It broke the styling of our app as we don't have a way to style this enclosing div.

By using `cloneElement` no extra markup is generated.