### PR TITLE
Changed const to var

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 // http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default
 
-const lib = require("./build")
+var lib = require("./build")
 module.exports = lib.default


### PR DESCRIPTION
This is for support in IE 10 which does not support the const keyword, and since react-popover will usually be in node_modules it will not bundle correctly (hence with var instead of const) even with babel or similar.