### PR TITLE
Add ability to pass in custom Tip component

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,3 +99,8 @@ Defines the size of the tip pointer.  Use .01 to disable tip.  Defaults to '7'.
 
 - The DOM selector where this popover will be appended to. Default to 'body'.
 
+---
+
+#### `Tip :: React Component`
+
+- The React Component to use when rendering the tip of the popover. Default to built-in `Tip`.

--- a/examples/playground/main.js
+++ b/examples/playground/main.js
@@ -159,6 +159,7 @@ const Demo = createReactClass({
             E.option({ key: "custom", value: "custom" }, "custom")
           ]
         )
+
       )
     )
 

--- a/examples/playground/main.js
+++ b/examples/playground/main.js
@@ -23,8 +23,7 @@ const createOption = (type) => (
     key: type,
     value: type,
     children: type
-  })
-)
+  }))
 
 const createPreferPlaceOptions = R.compose(
   R.prepend([E.option({ key: "null", value: null }, "null")]),
@@ -33,6 +32,40 @@ const createPreferPlaceOptions = R.compose(
   R.map(R.path(["values"])),
   R.path(["types"])
 )
+
+const CustomTip = createReactClass({
+  displayName: "tip",
+  render () {
+    const { direction } = this.props
+    const size = this.props.size || 24
+    const isPortrait = direction === "up" || direction === "down"
+    const mainLength = size
+    const crossLength = size * 2
+    const points = (
+      direction === "up" ? `0,${mainLength} ${mainLength},0, ${crossLength},${mainLength}`
+      : direction === "down" ? `0,0 ${mainLength},${mainLength}, ${crossLength},0`
+      : direction === "left" ? `${mainLength},0 0,${mainLength}, ${mainLength},${crossLength}`
+      : `0,0 ${mainLength},${mainLength}, 0,${crossLength}`
+    )
+    const props = {
+      className: "Popover-tip",
+      width: isPortrait ? crossLength : mainLength,
+      height: isPortrait ? mainLength : crossLength,
+    }
+    const triangle = (
+      E.svg(props,
+        E.polygon({
+          className: "customTip",
+          fill: "red",
+          points,
+        })
+      )
+    )
+    return (
+      triangle
+    )
+  },
+})
 
 const Demo = createReactClass({
   displayName: "demo",
@@ -59,6 +92,10 @@ const Demo = createReactClass({
   changePlace (event) {
     const place = event.target.value === "null" ? null : event.target.value
     this.setState({ place })
+  },
+  changeTip (event) {
+    const TipCls = event.target.value === "null" ? undefined : CustomTip
+    this.setState({ TipCls })
   },
   render () {
     debug("render")
@@ -93,6 +130,7 @@ const Demo = createReactClass({
     )
 
     const popoverProps = {
+      Tip: this.state.TipCls,
       isOpen: this.state.popoverIsOpen,
       preferPlace: this.state.preferPlace,
       place: this.state.place,
@@ -112,8 +150,14 @@ const Demo = createReactClass({
         E.label({ htmlFor: "place" }, "place "),
         E.select({ id: "place", onChange: this.changePlace },
           createPreferPlaceOptions(Layout)
+        ),
+        E.label({ htmlFor: "tip" }, "tip "),
+        E.select({ id: "tip", onChange: this.changeTip },
+          [
+            E.option({ key: "null", value: null }, "null"),
+            E.option({ key: "custom", value: "custom" }, "custom")
+          ]
         )
-
       )
     )
 

--- a/examples/playground/main.js
+++ b/examples/playground/main.js
@@ -23,7 +23,8 @@ const createOption = (type) => (
     key: type,
     value: type,
     children: type
-  }))
+  })
+)
 
 const createPreferPlaceOptions = R.compose(
   R.prepend([E.option({ key: "null", value: null }, "null")]),

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,7 @@ const Popover = createReactClass({
   propTypes: {
     body: T.node.isRequired,
     children: T.element.isRequired,
+    Tip: T.func,
     appendTarget: T.string,
     className: T.string,
     enterExitTransitionDurationMs: T.number,
@@ -79,6 +80,7 @@ const Popover = createReactClass({
   mixins: [ReactLayerMixin()],
   getDefaultProps () {
     return {
+      Tip,
       tipSize: 7,
       preferPlace: null,
       place: null,
@@ -465,7 +467,7 @@ const Popover = createReactClass({
     return (
       E.div(popoverProps,
         E.div({ className: "Popover-body" }, ...popoverBody),
-        createElement(Tip, tipProps)
+        createElement(this.props.Tip, tipProps)
       )
     )
   },


### PR DESCRIPTION
NOTE: This is actually a change I'd like to submit to  `0.4.x` as I need it with `react@15`, but I didn't see a branch for that, so I thought I'd submit it here as a way to start the conversation. 

- Adds a new, optional `Tip` property which allows a custom `Tip` component to be used by `Popover`. 
- Adds documentation of new `Tip` property
- Adds a new select in the playground example to allow toggling between built-in and custom `Tip`

I didn't see much in the way of tests for `Popover` itself, so I wasn't sure what to do on that front. I'd be happy to add tests for this feature given a little guidance about how you'd like the tests written. 