### PR TITLE
[WIP] Don't merge -- Support ReactDOM^15.0.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,13 @@ import Platform from "./platform"
 import Utils from "./utils"
 import Tip from "./tip"
 
+// Based off of a similar check in reactjs/react-modal
+const isReact16 = ReactDOM.createPortal !== undefined
+
+const createPortal = (parent, child, container) => isReact16
+  ? ReactDOM.createPortal(child, container)
+  : ReactDOM.unstable_renderSubtreeIntoContainer(parent, child, container)
+
 const log = Debug("react-popover")
 
 const supportedCSSValue = Utils.clientOnly(cssVendor.supportedValue)
@@ -94,6 +101,16 @@ class Popover extends React.Component {
     use it. We have a legitimate use-case. */
     // eslint-disable-next-line
     this.targetEl = ReactDOM.findDOMNode(this)
+
+    if (isReact16) {
+      this.appendTarget = this.props.appendTarget
+    } else {
+      const appendTargetChild = Platform.document.createElement('div')
+      this.props.appendTarget.appendChild(appendTargetChild)
+      this.appendTarget = appendTargetChild
+      this.renderPopover()
+    }
+
     if (this.props.isOpen) this.enter()
   }
   componentWillReceiveProps(propsNext) {
@@ -108,6 +125,19 @@ class Popover extends React.Component {
     //log(`Component did update!`)
     const didOpen = !statePrev.toggle && this.state.toggle
     const didClose = statePrev.toggle && !this.state.toggle
+    const didChange = statePrev.toggle !== this.state.toggle
+
+    if (!isReact16) {
+      if (didChange) {
+        didClose && propsPrev.appendTarget.removeChild(this.appendTarget)
+        didOpen && this.props.appendTarget.appendChild(this.appendTarget)
+        this.renderPopover()
+      } else if (propsPrev.appendTarget !== this.props.appendTarget) {
+        propsPrev.appendTarget.removeChild(this.appendTarget)
+        this.props.appendTarget.appendChild(this.appendTarget)
+        this.renderPopover()
+      }
+    }
 
     if (didOpen) this.enter()
     else if (didClose) this.exit()
@@ -120,6 +150,11 @@ class Popover extends React.Component {
     initialization never took place and so calling untrack
     would be an error. Also see issue 55. */
     if (this.hasTracked) this.untrackPopover()
+
+    if (!isReact16) {
+      ReactDOM.unmountComponentAtNode(this.appendTarget)
+      this.props.appendTarget.removeChild(this.appendTarget)
+    }
   }
   resolvePopoverLayout() {
     /* Find the optimal zone to position self. Measure the size of each zone and use the one with
@@ -246,7 +281,7 @@ class Popover extends React.Component {
 
     /* Apply Absolute Positioning. */
 
-    log("pos", pos)
+    // log("pos", pos)
     this.containerEl.style.top = `${pos.y}px`
     this.containerEl.style.left = `${pos.x}px`
 
@@ -307,12 +342,12 @@ class Popover extends React.Component {
   }
   enter() {
     if (Platform.isServer) return
-    log("enter!")
+    // log("enter!")
     this.trackPopover()
     this.animateEnter()
   }
   exit() {
-    log("exit!")
+    // log("exit!")
     this.animateExit()
     this.untrackPopover()
   }
@@ -480,26 +515,34 @@ class Popover extends React.Component {
   getContainerNodeRef = containerEl => {
     Object.assign(this, { containerEl })
   }
-  render() {
+  renderPopover() {
     const { className = "", style = {}, tipSize } = this.props
-    const { standing } = this.state
+    const { exited, standing } = this.state
+
+    if (exited) {
+      return null
+    }
 
     const popoverProps = {
       className: `Popover Popover-${standing} ${className}`,
       style: { ...coreStyle, ...style },
     }
 
-    const popover = this.state.exited ? null : (
+    const popover = (
       <div ref={this.getContainerNodeRef} {...popoverProps}>
         <div className="Popover-body" children={this.props.body} />
         <Tip direction={faces[standing]} size={tipSize} />
       </div>
     )
-    return [
-      this.props.children,
-      Platform.isClient &&
-        ReactDOM.createPortal(popover, this.props.appendTarget),
-    ]
+
+    return Platform.isClient && createPortal(this, popover, this.appendTarget)
+  }
+  render() {
+    if (isReact16) {
+      return [this.props.children, this.renderPopover()]
+    }
+
+    return this.props.children
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "lodash.throttle": "^3.0.3",
     "prop-types": "^15.5.10"
   },
+  "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/littlebits/react-popover.git"
@@ -40,8 +44,8 @@
     "eslint-config-littlebits": "^0.6.2",
     "prettier": "^1.7.3",
     "ramda": "^0.18.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0",
     "react-draggable": "3.0.3",
     "react-test-renderer": "16",
     "release": "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2152,6 +2152,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-class@^15.6.0:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cross-spawn@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -5321,14 +5329,14 @@ react-dom-factories@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
 
-react-dom@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
+react-dom@^15.0.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:
-    fbjs "^0.8.16"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
 
 react-draggable@3.0.3:
   version "3.0.3"
@@ -5445,14 +5453,15 @@ react-treebeard@^2.0.3:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+react@^15.0.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
-    fbjs "^0.8.16"
+    create-react-class "^15.6.0"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
@jasonkuhrt I wanted to check in to see if this was something you'd be ok with merging. I mentioned in my comment in #149 that this would be a quick change, but it's actually rather complex. I've got it mostly working, but looking at it now I'm not sure the gains outweigh the additional maintenance cost of the additional complexity.

The overall strategy is:
* Choose between `ReactDOM.createPortal` and `ReactDOM.unstable_renderSubtreeIntoContainer`
* If using the latter, manually add, track, and remove the DOM nodes used to contain the popover

Thanks!