### PR TITLE
Add a tabindex of -1 to the resize-sensor element

### DIFF
--- a/lib/on-resize.js
+++ b/lib/on-resize.js
@@ -36,6 +36,7 @@ const createElementHack = () => {
   el.className = "resize-sensor"
   el.setAttribute("style", "display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;")
   el.setAttribute("class", "resize-sensor")
+  el.setAttribute("tabindex", "-1")
   el.type = "text/html"
   el.data = "about:blank"
   return el


### PR DESCRIPTION
This is to prevent the resize sensor from hijacking the tabindex of other elements. Fixes #142 