### PR TITLE
Remove children from required props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ const flowToPopoverTranslations = {
 class Popover extends React.Component {
   static propTypes = {
     body: T.node.isRequired,
-    children: T.element.isRequired,
+    children: T.element,
     appendTarget: T.object,
     className: T.string,
     enterExitTransitionDurationMs: T.number,


### PR DESCRIPTION
https://github.com/littlebits/react-popover/issues/85

children shouldn't be required if you also are required to pass in the content of the popover in as a body prop.