### PR TITLE
Add aria props to improve assistive tech accessibility

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -97,7 +97,7 @@ Defines the size of the tip pointer.  Use .01 to disable tip.  Defaults to '7'.
 
 ## Accessibility
 
-react-popover tries to ensure the popover will be accessible for screen reader technology, however if the content is complex or the parent element of the popover content is not visibly rendered you may have to supply the popover the `aria-describedby` attribute with the `Popover-body` manually:
+react-popover tries to ensure the popover will be accessible for screen reader technology, however if the content is complex or multiple children elements are passed in you will have to supply the popover the `aria-describedby` attribute with the `Popover-body` manually:
 ```js
 <Popover isOpen={isOpen} body="This is where you would explain stuff">
   <MyComplexComponent

--- a/README.adoc
+++ b/README.adoc
@@ -94,3 +94,41 @@ Defines the size of the tip pointer.  Use .01 to disable tip.  Defaults to '7'.
 #### `appendTarget :: DOMElement`
 
 - The DOM element which the https://reactjs.org/docs/portals.html[portal] will mount into. In effect the popover will become an appended child of this DOM element. Defaults to 'document.body'.
+
+## Accessibility
+
+react-popover tries to ensure the popover will be accessible for screen reader technology, however if the content is complex or the parent element of the popover content is not visibly rendered you may have to supply the popover the `aria-describedby` attribute with the `Popover-body` manually:
+```js
+<Popover isOpen={isOpen} body="This is where you would explain stuff">
+  <MyComplexComponent
+    aria-describedby="Popover-body"
+  />
+</Popover>
+```
+
+### Keyboard accessibility
+
+To ensure your popover can be used without a mouse it's important to ensure the popover can be interacted with only using the keyboard. This can be accomplished with the `onBlur` and `onFocus` handlers, as well as the `tabIndex` prop:
+```js
+// this allows the popover tooltip to be closed even if its still focused on.
+closePopoverWhenEscaping = event => {
+  if (event.key === "Escape") {
+    this.hidePopover
+  }
+}
+
+<Popover isOpen={isOpen} body="This is where you would explain stuff">
+  <div
+    tabIndex="0" // this allows the div to be reached using the tab key
+    className="Row"
+    onMouseOver={() => this.showPopover}
+    onMouseOut={() => this.hidePopover}
+    onFocus={() => this.showPopover} // this shows the Popover tooltip when someone tabs to this div
+    onBlur={() => this.hidePopover} // this hides the Popover tooltip when someone tabs away from this div
+    onKeyDown={this.closePopoverWhenEscaping}
+    children={this.props.children}
+  />
+</Popover>
+```
+
+Additional information on keyboard accessibility can be found on the [webAIM website](https://webaim.org/techniques/keyboard/)

--- a/README.adoc
+++ b/README.adoc
@@ -131,4 +131,4 @@ closePopoverWhenEscaping = event => {
 </Popover>
 ```
 
-Additional information on keyboard accessibility can be found on the [webAIM website](https://webaim.org/techniques/keyboard/)
+Additional information on keyboard accessibility can be found on the https://webaim.org/techniques/keyboard/[webAIM website]

--- a/source/index.js
+++ b/source/index.js
@@ -489,6 +489,10 @@ class Popover extends React.Component {
   render() {
     const { className = "", style = {}, tipSize } = this.props
     const { standing } = this.state
+    const popoverBodyId = "Popover-body"
+    const childWithAccessibility = React.cloneElement(this.props.children, {
+      "aria-describedby": popoverBodyId,
+    })
 
     const popoverProps = {
       className: `Popover Popover-${standing} ${className}`,
@@ -497,12 +501,17 @@ class Popover extends React.Component {
 
     const popover = this.state.exited ? null : (
       <div ref={this.getContainerNodeRef} {...popoverProps}>
-        <div className="Popover-body" children={this.props.body} />
+        <div
+          className="Popover-body"
+          id={popoverBodyId}
+          children={this.props.body}
+          role="tooltip"
+        />
         <Tip direction={faces[standing]} size={tipSize} />
       </div>
     )
     return [
-      this.props.children,
+      childWithAccessibility,
       Platform.isClient &&
         ReactDOM.createPortal(popover, this.props.appendTarget),
     ]

--- a/source/index.js
+++ b/source/index.js
@@ -486,13 +486,22 @@ class Popover extends React.Component {
   getContainerNodeRef = containerEl => {
     Object.assign(this, { containerEl })
   }
+  childrenWithOptionalAccessibilityProps(popoverBodyId) {
+    const { children } = this.props
+
+    if (React.Children.count(children) === 1) {
+      return React.cloneElement(this.props.children, {
+        "aria-describedby": popoverBodyId,
+      })
+    } else {
+      return children
+    }
+  }
+
   render() {
     const { className = "", style = {}, tipSize } = this.props
     const { standing } = this.state
     const popoverBodyId = "Popover-body"
-    const childWithAccessibility = React.cloneElement(this.props.children, {
-      "aria-describedby": popoverBodyId,
-    })
 
     const popoverProps = {
       className: `Popover Popover-${standing} ${className}`,
@@ -511,7 +520,7 @@ class Popover extends React.Component {
       </div>
     )
     return [
-      childWithAccessibility,
+      this.childrenWithOptionalAccessibilityProps(popoverBodyId),
       Platform.isClient &&
         ReactDOM.createPortal(popover, this.props.appendTarget),
     ]

--- a/stories/playground/main.js
+++ b/stories/playground/main.js
@@ -35,6 +35,12 @@ class Main extends React.Component {
       popoverIsOpen,
     })
   }
+  closePopoverWhenEscaping(event) {
+    debug("closePopoverWhenEscaping")
+    if (event.key === "Escape") {
+      this.togglePopover(false)
+    }
+  }
   changePreferPlace(event) {
     const preferPlace =
       event.target.value === "null" ? null : event.target.value
@@ -56,7 +62,12 @@ class Main extends React.Component {
 
     const targetToggleProps = {
       className: "Target-Toggle",
+      tabIndex: "0",
+      "aria-describedby": "Popover-body",
       onClick: e => this.togglePopover(e),
+      onKeyDown: e => this.closePopoverWhenEscaping(e),
+      onFocus: e => this.togglePopover(true),
+      onBlur: e => this.togglePopover(false),
     }
 
     const targetMoveProps = {

--- a/stories/rows/main.js
+++ b/stories/rows/main.js
@@ -11,17 +11,26 @@ class Row extends React.Component {
   toggle(toState = null) {
     this.setState({ isOpen: toState === null ? !this.state.isOpen : toState })
   }
+  closePopoverWhenEscaping = event => {
+    if (event.key === "Escape") {
+      this.toggle(false)
+    }
+  }
   render() {
     const { isOpen } = this.state
     return (
       <Popover
         isOpen={isOpen}
-        body="!"
+        body="This is where you would explain stuff"
         children={
           <div
+            tabIndex="0"
             className="Row"
             onMouseOver={() => this.toggle(true)}
             onMouseOut={() => this.toggle(false)}
+            onFocus={() => this.toggle(true)}
+            onBlur={() => this.toggle(false)}
+            onKeyDown={this.closePopoverWhenEscaping}
             children={this.props.children}
           />
         }


### PR DESCRIPTION
This PR adds the aria labels to allow assistive tech (such as screen readers) integrate better with react-popover, and hopefully go a little way to closing out #161 😄 

## How it works
The tooltip body is given a `role=tooltip` to identify it is a tooltip to accessibility tech and an `id=Popover-body` to identify the element. The children passed into the `Popover` component are cloned and given an `aria-describedby=Popover-body` to link both the tooltip content and the triggering element.

This results in the contents of the popover being read by a screen reader when it is shown.

## Caveats/Discussion points
- This seems to only be truly effective when combined with keyboard navigation. Because react-popover doesn't make any assumptions about how it should be shown or hidden it's a really flexible component, unfortunately the downside of that means we can't really enforce keyboard navigation in a way that makes the screen reading functionality as seamless as it could be. Consumers of the package still need to ensure that their components are keyboard accessible to get the most out of this.
- With complex children (such as the one created by react-draggable in the story) if the parent element being passed in is not being rendered to the screen the accessibility won't work properly. In this case the `aria-describedby=Popover-body` will need to be set by the user on a meaningful element.
- I'm adding the `aria-describedby` prop by cloning the children prop passed into the `Popover` component and then returning, which could have performance impacts for large popovers/components that get re-rendered a lot.
- I wasn't sure what a reasonable default would be in the case that multiple children elements are passed into the `Popover` component, so I opted to not attach an aria label, and leave that up to the user to define. I don't predict this will be a big issue, since the PropTypes specify that the `children` prop should only be a single element, but I wanted to ensure I wasn't actively breaking components with multiple children.
- Apparently there are some differences between different screen reader tech, so I can only be certain this works as intended on a Mac OS
- I'm still pretty new to write accessible JS code, so this might not be completely up to par 😄 
