### PR TITLE
Add prop to specify whether popover should unmount on exit

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,6 +78,11 @@ Defines the size of the tip pointer.  Use .01 to disable tip.  Defaults to '7'.
 
 ---
 
+#### `unmountOnExit :: Boolean`
+Defines whether to unmount the popover component when hidden. Defaults to 'true'.
+
+---
+
 ##### Standard
 
 * Properties like `className` and `style`.

--- a/source/index.js
+++ b/source/index.js
@@ -61,6 +61,7 @@ class Popover extends React.Component {
     refreshIntervalMs: T.oneOfType([T.number, T.bool]),
     style: T.object,
     tipSize: T.number,
+    unmountOnExit: T.bool,
     onOuterAction: T.func,
   }
   static defaultProps = {
@@ -73,6 +74,7 @@ class Popover extends React.Component {
     enterExitTransitionDurationMs: 500,
     children: null,
     refreshIntervalMs: 200,
+    unmountOnExit: true,
     appendTarget: Platform.isClient ? Platform.document.body : null,
   }
   constructor(props) {
@@ -492,15 +494,20 @@ class Popover extends React.Component {
 
     const popoverProps = {
       className: `Popover Popover-${standing} ${className}`,
-      style: { ...coreStyle, ...style },
+      style: {
+        ...coreStyle,
+        display: this.props.isOpen || this.state.exiting ? "flex" : "none",
+        ...style,
+      },
     }
 
-    const popover = this.state.exited ? null : (
-      <div ref={this.getContainerNodeRef} {...popoverProps}>
-        <div className="Popover-body" children={this.props.body} />
-        <Tip direction={faces[standing]} size={tipSize} />
-      </div>
-    )
+    const popover =
+      this.state.exited && this.props.unmountOnExit ? null : (
+        <div ref={this.getContainerNodeRef} {...popoverProps}>
+          <div className="Popover-body" children={this.props.body} />
+          <Tip direction={faces[standing]} size={tipSize} />
+        </div>
+      )
     return [
       this.props.children,
       Platform.isClient &&

--- a/stories/playground/main.js
+++ b/stories/playground/main.js
@@ -26,6 +26,7 @@ class Main extends React.Component {
     popoverIsOpen: false,
     preferPlace: null,
     place: null,
+    unmountOnExit: true,
   }
   togglePopover(toState) {
     debug("togglePopover")
@@ -43,6 +44,10 @@ class Main extends React.Component {
   changePlace(event) {
     const place = event.target.value === "null" ? null : event.target.value
     this.setState({ place })
+  }
+  changeUnmountOnExit(event) {
+    const unmountOnExit = event.target.value === "true"
+    this.setState({ unmountOnExit })
   }
   render() {
     debug("render")
@@ -80,6 +85,7 @@ class Main extends React.Component {
       isOpen: this.state.popoverIsOpen,
       preferPlace: this.state.preferPlace,
       place: this.state.place,
+      unmountOnExit: this.state.unmountOnExit,
       onOuterAction: () => this.togglePopover(false),
       body: [
         <h1 key="a">Popover Title</h1>,
@@ -96,6 +102,11 @@ class Main extends React.Component {
         <label htmlFor="place">place </label>
         <select id="place" onChange={e => this.changePlace(e)}>
           {createPreferPlaceOptions(Layout)}
+        </select>
+        <label htmlFor="unmount">unmountOnExit </label>
+        <select id="unmount" onChange={e => this.changeUnmountOnExit(e)}>
+          <option value="true">true</option>
+          <option value="false">false</option>
         </select>
       </form>
     )


### PR DESCRIPTION
We had a situation where we needed a component in the popover body to stay mounted, and wanted to give this option to others.

This defaults to the existing behavior of unmounting when the popover is closed, but provides the option to keep it mounted if desired.