### PR TITLE
Update README: add offset prop info

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,10 +78,14 @@ Defines the size of the tip pointer.  Use .01 to disable tip.  Defaults to '7'.
 
 ---
 
+#### `offset :: Number`
+Offset allows users to control the distance betweent the tip and the target. Defaults to '4'.
+
+---
+
 ##### Standard
 
 * Properties like `className` and `style`.
-
 
 ---
 


### PR DESCRIPTION
I ran into a problem and only after debugging source code I realize that it can be fixed by combination of `tipSize` and `offset` props. But info about `offset` prop is missing in docs.