### PR TITLE
Update index.js for better js backwards compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
 // http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default
 
-const lib = require("./build")
-module.exports = lib.default
+module.exports = require("./build").default


### PR DESCRIPTION
This file is not run through `babel` but it uses `const`.  The other files that are run through babel replace `const` with `var`, so this is the only file that won't work in a browser that doesn't support `const`.  For example, an iOS 8 device.