### PR TITLE
feat(positions-enum): add a static positions property on the Popover component

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,8 @@ Sets a ***preference*** of where to position the Popover. Only useful to specify
 `start | end` :: Prefer an order.
 `null` :: No preference, automatic resolution. This is the default.
 
+Can use the `static` `POSITIONS` property on the `Popover` component to help reference these values (e.g. `Popover.POSITIONS.START` or `Popover.POSITIONS.ABOVE`)
+
 ---
 
 ##### `place :: String | Null`

--- a/source/index.js
+++ b/source/index.js
@@ -4,7 +4,7 @@ import throttle from "lodash.throttle"
 import T from "prop-types"
 import React from "react"
 import ReactDOM from "react-dom"
-import Layout from "./layout"
+import Layout, {POSITIONS} from "./layout"
 import resizeEvent from "./on-resize"
 import Platform from "./platform"
 import Tip from "./tip"
@@ -48,6 +48,7 @@ const flowToPopoverTranslations = {
 }
 
 class Popover extends React.Component {
+  static POSITIONS = POSITIONS
   static propTypes = {
     body: T.node.isRequired,
     children: T.element.isRequired,

--- a/source/layout.js
+++ b/source/layout.js
@@ -32,6 +32,14 @@ const types = [
 ]
 
 const validTypeValues = types.reduce((xs, { values }) => xs.concat(values), [])
+const POSITIONS = Object.freeze(
+  Object.assign(
+    {},
+    ...validTypeValues.map(
+      value => ({[value.toUpperCase()]: value})
+    )
+  )
+);
 
 const centerOfSize = (flow, axis, size) => size[axes[flow][axis].size] / 2
 
@@ -252,6 +260,7 @@ export default {
   calcRelPos,
   place,
   pickZone,
+  POSITIONS,
   axes,
   centerOfSize,
   centerOfBounds,
@@ -266,6 +275,7 @@ export {
   calcRelPos,
   place,
   pickZone,
+  POSITIONS,
   axes,
   centerOfSize,
   centerOfBounds,

--- a/stories/playground/main.js
+++ b/stories/playground/main.js
@@ -16,9 +16,8 @@ const Option = type => <option key={type} value={type} children={type} />
 const createPreferPlaceOptions = R.compose(
   R.prepend([<option key="null" value={null} children="null" />]),
   R.map(Option),
-  R.flatten,
-  R.map(R.path(["values"])),
-  R.path(["types"]),
+  R.values,
+  R.path(["POSITIONS"]),
 )
 
 class Main extends React.Component {


### PR DESCRIPTION
### Summary

When using this component, we have an object that basically serves as an `enum` for the various position preferences we might need for different `Popover` use-cases.

I was hoping of adding this `enum` as part of the public API for this library.

#### Where To Add The `enum`

I noticed that this library has a single `module.exports` value (the `Popover` component) which is why I went with the `static` property on `Popover` directly vs. adding a named property on the `module.exports` object that would reference the `POSITIONS` enum object (my understanding is that doing something like `module.exports.POSITIONS = lib.POSITIONS` would effectively be like adding the `static` property anyways since `module.exports` would reference the exported `Popover` component).

#### Testing Modifications (i.e. `Storybook`)

I modified the underlying `Storybook` stories to use the new `POSITIONS` enum (exported from `layout.js`) to sanity check my changes.

![Kapture 2020-05-22 at 0 54 12](https://user-images.githubusercontent.com/8136030/82632639-cf2ec480-9bc6-11ea-9579-b0d686b898b4.gif)

Feel free to modify the naming pattern for the `enum` - I've just seen a general pattern of `UPCASE` enum names and `UPCASE` for the underlying property names